### PR TITLE
Ensure modules only under src/sentience

### DIFF
--- a/src/sentience/cli/__main__.py
+++ b/src/sentience/cli/__main__.py
@@ -1,4 +1,4 @@
-# sentience_cli.py
+# sentience.cli.__main__
 """
 Command-line interface for testing Sentience locally
 Provides OAuth flow handling and interactive querying


### PR DESCRIPTION
## Summary
- update cli module header comment to reflect its new location
- confirm entrypoints in `pyproject.toml`

## Testing
- `pytest -q`
- `sentience-cli` (expect config setup wizard)
- `sentience-api` (fails to start without config)

------
https://chatgpt.com/codex/tasks/task_e_68743bf191d08331862ca5dc6d878892