### PR TITLE
Secure refresh token storage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,7 @@ EVE_CALLBACK_URL=http://localhost:8000/callback
 
 # OpenAI Configuration
 OPENAI_API_KEY=your_openai_api_key_here
+FERNET_KEY=generate_with_python
 
 # Application Settings
 LOG_LEVEL=INFO

--- a/README.md
+++ b/README.md
@@ -74,7 +74,8 @@ git clone https://github.com/yourname/sentience-eve.git
 cd sentience-eve
 pip install -e .
 cp .env.example .env
-# Fill in ESI/OpenAI/Redis credentials
+# Fill in ESI/OpenAI credentials and generate a Fernet key
+# python -c 'from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())'
 ```
 
 You can now run the interactive CLI or start the API server:

--- a/sentience-setup.md
+++ b/sentience-setup.md
@@ -128,6 +128,8 @@ cp .env.example .env
 EVE_CLIENT_ID="your_client_id"
 EVE_CLIENT_SECRET="your_client_secret"
 OPENAI_API_KEY="your_openai_key"
+FERNET_KEY="your_fernet_key"
+# generate with: python -c 'from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())'
 
 # Or run the interactive setup
 sentience-cli
@@ -321,7 +323,8 @@ htmlcov/
   "client_id": "your_eve_client_id_here",
   "client_secret": "your_eve_client_secret_here",
   "callback_url": "http://localhost:8000/callback",
-  "openai_api_key": "your_openai_api_key_here"
+  "openai_api_key": "your_openai_api_key_here",
+  "fernet_key": "generate_with_python"
 }
 ```
 

--- a/src/sentience/api/server.py
+++ b/src/sentience/api/server.py
@@ -18,6 +18,7 @@ from pydantic import BaseModel, Field
 
 from sentience.core import SentienceCore
 from sentience.models import EVECharacter
+from sentience.utils import SecureTokenManager
 from sentience.utils.config import get_config
 
 logger = logging.getLogger(__name__)
@@ -25,13 +26,15 @@ logger = logging.getLogger(__name__)
 
 # Pydantic models for API
 class AuthStartRequest(BaseModel):
-    scopes: Optional[List[str]] = Field(default=[
-        "esi-wallet.read_character_wallet.v1",
-        "esi-assets.read_assets.v1",
-        "esi-skills.read_skills.v1",
-        "esi-industry.read_character_jobs.v1",
-        "esi-markets.read_character_orders.v1"
-    ])
+    scopes: Optional[List[str]] = Field(
+        default=[
+            "esi-wallet.read_character_wallet.v1",
+            "esi-assets.read_assets.v1",
+            "esi-skills.read_skills.v1",
+            "esi-industry.read_character_jobs.v1",
+            "esi-markets.read_character_orders.v1",
+        ]
+    )
 
 
 class AuthStartResponse(BaseModel):
@@ -67,34 +70,36 @@ class DataPreview(BaseModel):
 # Global storage (in production, use Redis or similar)
 auth_sessions: Dict[str, dict] = {}
 app_sentience: Optional[SentienceCore] = None
+token_manager: Optional[SecureTokenManager] = None
 
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     """Manage application lifecycle"""
-    global app_sentience
-    
+    global app_sentience, token_manager
+
     # Load configuration
     config = get_config()
     config.setup_logging()
-    
+
     if not config.validate():
         logger.error("Invalid configuration. Please check your config.")
         raise RuntimeError("Invalid configuration")
-    
-    # Initialize Sentience core
+
+    # Initialize Sentience core and token manager
     app_sentience = SentienceCore(
-        client_id=config.get('client_id'),
-        client_secret=config.get('client_secret'),
-        callback_url=config.get('callback_url', 'http://localhost:8000/callback'),
-        openai_api_key=config.get('openai_api_key')
+        client_id=config.get("client_id"),
+        client_secret=config.get("client_secret"),
+        callback_url=config.get("callback_url", "http://localhost:8000/callback"),
+        openai_api_key=config.get("openai_api_key"),
     )
-    
+    token_manager = SecureTokenManager(config.get("fernet_key"))
+
     # Load saved characters if any
     load_saved_characters()
-    
+
     yield
-    
+
     # Cleanup
     save_characters()
 
@@ -103,7 +108,7 @@ app = FastAPI(
     title="Sentience API",
     description="EVE Online AI Co-Pilot API",
     version="1.0.0",
-    lifespan=lifespan
+    lifespan=lifespan,
 )
 
 # CORS configuration
@@ -118,56 +123,63 @@ app.add_middleware(
 
 def load_saved_characters():
     """Load previously authenticated characters"""
-    global app_sentience
-    
-    character_dir = Path('characters')
+    global app_sentience, token_manager
+
+    character_dir = Path("characters")
     if not character_dir.exists():
         return
-        
-    for char_file in character_dir.glob('character_*.json'):
+
+    for char_file in character_dir.glob("character_*.json"):
         try:
-            with open(char_file, 'r') as f:
+            with open(char_file) as f:
                 char_data = json.load(f)
-                
+
             # Recreate character object
+            refresh_token = token_manager.load_token(str(char_data["character_id"]))
+            if not refresh_token:
+                refresh_token = char_data.get("refresh_token", "")
+                if refresh_token:
+                    token_manager.save_token(str(char_data["character_id"]), refresh_token)
+
             character = EVECharacter(
-                character_id=char_data['character_id'],
-                character_name=char_data['character_name'],
-                access_token='',  # Will be refreshed on first use
-                refresh_token=char_data['refresh_token'],
+                character_id=char_data["character_id"],
+                character_name=char_data["character_name"],
+                access_token="",  # Will be refreshed on first use
+                refresh_token=refresh_token,
                 token_expiry=datetime.utcnow(),  # Force refresh
-                scopes=char_data['scopes']
+                scopes=char_data["scopes"],
             )
-            
+
             app_sentience.characters[str(character.character_id)] = character
             logger.info(f"Loaded character: {character.character_name}")
-            
+
         except Exception as e:
             logger.error(f"Failed to load character from {char_file}: {e}")
 
 
 def save_characters():
     """Save authenticated characters"""
-    global app_sentience
-    
+    global app_sentience, token_manager
+
     if not app_sentience:
         return
-        
-    character_dir = Path('characters')
+
+    character_dir = Path("characters")
     character_dir.mkdir(exist_ok=True)
-    
+
     for char_id, character in app_sentience.characters.items():
         char_file = character_dir / f"character_{character.character_id}.json"
         char_data = {
-            'character_id': character.character_id,
-            'character_name': character.character_name,
-            'refresh_token': character.refresh_token,
-            'scopes': character.scopes,
-            'last_updated': datetime.utcnow().isoformat()
+            "character_id": character.character_id,
+            "character_name": character.character_name,
+            "scopes": character.scopes,
+            "last_updated": datetime.utcnow().isoformat(),
         }
-        
-        with open(char_file, 'w') as f:
+
+        with open(char_file, "w") as f:
             json.dump(char_data, f, indent=2)
+
+        token_manager.save_token(str(character.character_id), character.refresh_token)
 
 
 @app.get("/")
@@ -181,8 +193,8 @@ async def root():
             "callback": "/callback",
             "query": "/query",
             "characters": "/characters",
-            "data_preview": "/data/{character_id}"
-        }
+            "data_preview": "/data/{character_id}",
+        },
     }
 
 
@@ -190,72 +202,73 @@ async def root():
 async def start_auth(request: AuthStartRequest):
     """Start OAuth authentication flow"""
     global app_sentience, auth_sessions
-    
+
     if not app_sentience:
         raise HTTPException(status_code=500, detail="Service not initialized")
-    
+
     # Generate auth URL
     auth_url, code_verifier = app_sentience.esi_client.generate_auth_url(request.scopes)
-    
+
     # Create session
     session_id = secrets.token_urlsafe(32)
     auth_sessions[session_id] = {
-        'code_verifier': code_verifier,
-        'created_at': datetime.utcnow(),
-        'scopes': request.scopes
+        "code_verifier": code_verifier,
+        "created_at": datetime.utcnow(),
+        "scopes": request.scopes,
     }
-    
-    return AuthStartResponse(
-        auth_url=auth_url,
-        session_id=session_id
-    )
+
+    return AuthStartResponse(auth_url=auth_url, session_id=session_id)
 
 
 @app.get("/callback")
 async def oauth_callback(
     code: str = Query(..., description="Authorization code from EVE SSO"),
-    state: Optional[str] = Query(None, description="State parameter")
+    state: Optional[str] = Query(None, description="State parameter"),
 ):
     """Handle OAuth callback from EVE SSO"""
     global app_sentience, auth_sessions
-    
+
     if not app_sentience:
         raise HTTPException(status_code=500, detail="Service not initialized")
-    
+
     # Find matching session
     session = None
     session_id = None
-    
+
     # In production, use state parameter to match session
     # For now, use the most recent session
     for sid, sess in auth_sessions.items():
-        if datetime.utcnow() - sess['created_at'] < timedelta(minutes=10):
+        if datetime.utcnow() - sess["created_at"] < timedelta(minutes=10):
             session = sess
             session_id = sid
             break
-    
+
     if not session:
-        return HTMLResponse(content="""
+        return HTMLResponse(
+            content="""
             <html>
             <body style="font-family: Arial, sans-serif; text-align: center; padding: 50px;">
                 <h1 style="color: #f44336;">Session Expired</h1>
                 <p>Please start the authentication process again.</p>
             </body>
             </html>
-        """, status_code=400)
-    
+        """,
+            status_code=400,
+        )
+
     try:
         # Add character
-        character = app_sentience.add_character(code, session['code_verifier'])
-        
+        character = app_sentience.add_character(code, session["code_verifier"])
+
         # Clean up session
         del auth_sessions[session_id]
-        
+
         # Save character
         save_characters()
-        
+
         # Return success page
-        return HTMLResponse(content=f"""
+        return HTMLResponse(
+            content=f"""
             <html>
             <body style="font-family: Arial, sans-serif; text-align: center; padding: 50px;">
                 <h1 style="color: #4CAF50;">Authentication Successful!</h1>
@@ -266,52 +279,56 @@ async def oauth_callback(
                 <p><small>Session ID: {session_id}</small></p>
             </body>
             </html>
-        """)
-        
+        """
+        )
+
     except Exception as e:
-        return HTMLResponse(content=f"""
+        return HTMLResponse(
+            content=f"""
             <html>
             <body style="font-family: Arial, sans-serif; text-align: center; padding: 50px;">
                 <h1 style="color: #f44336;">Authentication Failed</h1>
                 <p>Error: {str(e)}</p>
             </body>
             </html>
-        """, status_code=500)
+        """,
+            status_code=500,
+        )
 
 
 @app.post("/query", response_model=QueryResponse)
 async def query_assistant(request: QueryRequest):
     """Query the AI assistant with character context"""
     global app_sentience
-    
+
     if not app_sentience:
         raise HTTPException(status_code=500, detail="Service not initialized")
-    
+
     if request.character_id not in app_sentience.characters:
-        raise HTTPException(status_code=404, detail="Character not found. Please authenticate first.")
-    
+        raise HTTPException(
+            status_code=404, detail="Character not found. Please authenticate first."
+        )
+
     try:
         # Process query
         response = app_sentience.query_assistant(request.character_id, request.query)
         character = app_sentience.characters[request.character_id]
-        
+
         # Determine which data sources were used
         query_lower = request.query.lower()
         data_sources = []
-        
-        if any(word in query_lower for word in ['isk', 'wallet', 'balance', 'money']):
-            data_sources.append('wallet')
-        if any(word in query_lower for word in ['asset', 'item', 'ship', 'module']):
-            data_sources.append('assets')
-        if any(word in query_lower for word in ['skill', 'train', 'sp', 'skillpoint']):
-            data_sources.append('skills')
-        
+
+        if any(word in query_lower for word in ["isk", "wallet", "balance", "money"]):
+            data_sources.append("wallet")
+        if any(word in query_lower for word in ["asset", "item", "ship", "module"]):
+            data_sources.append("assets")
+        if any(word in query_lower for word in ["skill", "train", "sp", "skillpoint"]):
+            data_sources.append("skills")
+
         return QueryResponse(
-            response=response,
-            character_name=character.character_name,
-            data_sources=data_sources
+            response=response, character_name=character.character_name, data_sources=data_sources
         )
-        
+
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Query failed: {str(e)}")
 
@@ -320,19 +337,21 @@ async def query_assistant(request: QueryRequest):
 async def list_characters():
     """List all authenticated characters"""
     global app_sentience
-    
+
     if not app_sentience:
         raise HTTPException(status_code=500, detail="Service not initialized")
-    
+
     characters = []
     for char_id, character in app_sentience.characters.items():
-        characters.append(CharacterInfo(
-            character_id=character.character_id,
-            character_name=character.character_name,
-            authenticated_at=datetime.utcnow().isoformat(),
-            scopes=character.scopes
-        ))
-    
+        characters.append(
+            CharacterInfo(
+                character_id=character.character_id,
+                character_name=character.character_name,
+                authenticated_at=datetime.utcnow().isoformat(),
+                scopes=character.scopes,
+            )
+        )
+
     return characters
 
 
@@ -340,37 +359,37 @@ async def list_characters():
 async def get_data_preview(character_id: str):
     """Get a preview of character data"""
     global app_sentience
-    
+
     if not app_sentience:
         raise HTTPException(status_code=500, detail="Service not initialized")
-    
+
     if character_id not in app_sentience.characters:
         raise HTTPException(status_code=404, detail="Character not found")
-    
+
     character = app_sentience.characters[character_id]
     preview = DataPreview(last_updated=datetime.utcnow().isoformat())
-    
+
     try:
         # Fetch wallet
         wallet = app_sentience.esi_client.get_character_wallet(character)
         preview.wallet_balance = wallet.balance
     except Exception:
         pass
-    
+
     try:
         # Fetch assets
         assets = app_sentience.esi_client.get_character_assets(character)
         preview.total_assets = len(assets)
     except Exception:
         pass
-    
+
     try:
         # Fetch skills
         skills = app_sentience.esi_client.get_character_skills(character)
         preview.total_skillpoints = sum(s.skillpoints for s in skills)
     except Exception:
         pass
-    
+
     return preview
 
 
@@ -378,11 +397,11 @@ async def get_data_preview(character_id: str):
 async def health_check():
     """Health check endpoint"""
     global app_sentience
-    
+
     return {
         "status": "healthy" if app_sentience else "not_initialized",
         "timestamp": datetime.utcnow().isoformat(),
-        "characters_loaded": len(app_sentience.characters) if app_sentience else 0
+        "characters_loaded": len(app_sentience.characters) if app_sentience else 0,
     }
 
 
@@ -390,18 +409,12 @@ def run():
     """Run the API server"""
     # Get config for host/port settings
     config = get_config()
-    
-    host = config.get('api_host', '0.0.0.0')
-    port = config.get('api_port', 8000)
-    reload = config.get('api_reload', True)
-    
-    uvicorn.run(
-        "sentience.api.server:app",
-        host=host,
-        port=port,
-        reload=reload,
-        log_level="info"
-    )
+
+    host = config.get("api_host", "0.0.0.0")
+    port = config.get("api_port", 8000)
+    reload = config.get("api_reload", True)
+
+    uvicorn.run("sentience.api.server:app", host=host, port=port, reload=reload, log_level="info")
 
 
 if __name__ == "__main__":

--- a/src/sentience/cli/__main__.py
+++ b/src/sentience/cli/__main__.py
@@ -4,43 +4,43 @@ Command-line interface for testing Sentience locally
 Provides OAuth flow handling and interactive querying
 """
 
-import os
-import sys
 import json
+import os
 import threading
 import webbrowser
-from http.server import HTTPServer, BaseHTTPRequestHandler
-from urllib.parse import urlparse, parse_qs
 from datetime import datetime
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from urllib.parse import parse_qs, urlparse
 
 from sentience.core import SentienceCore
 from sentience.models import EVECharacter
+from sentience.utils import SecureTokenManager
 
 
 class OAuthCallbackHandler(BaseHTTPRequestHandler):
     """HTTP handler for OAuth callback"""
-    
+
     def log_message(self, format, *args):
         """Suppress default HTTP log messages"""
         pass
-        
+
     def do_GET(self):
         """Handle OAuth callback"""
         parsed_url = urlparse(self.path)
-        
-        if parsed_url.path == '/callback':
+
+        if parsed_url.path == "/callback":
             query_params = parse_qs(parsed_url.query)
-            
-            if 'code' in query_params:
+
+            if "code" in query_params:
                 # Store the authorization code
-                self.server.auth_code = query_params['code'][0]
-                self.server.state = query_params.get('state', [''])[0]
-                
+                self.server.auth_code = query_params["code"][0]
+                self.server.state = query_params.get("state", [""])[0]
+
                 # Send success response
                 self.send_response(200)
-                self.send_header('Content-type', 'text/html')
+                self.send_header("Content-type", "text/html")
                 self.end_headers()
-                
+
                 success_html = """
                 <html>
                 <body style="font-family: Arial, sans-serif; text-align: center; padding: 50px;">
@@ -54,9 +54,9 @@ class OAuthCallbackHandler(BaseHTTPRequestHandler):
             else:
                 # Handle error
                 self.send_response(400)
-                self.send_header('Content-type', 'text/html')
+                self.send_header("Content-type", "text/html")
                 self.end_headers()
-                
+
                 error_html = """
                 <html>
                 <body style="font-family: Arial, sans-serif; text-align: center; padding: 50px;">
@@ -73,69 +73,80 @@ class OAuthCallbackHandler(BaseHTTPRequestHandler):
 
 class SentienceCLI:
     """Command-line interface for Sentience"""
-    
+
     def __init__(self):
         # Load configuration
         self.config = self.load_config()
-        
+
         # Initialize core
         self.sentience = SentienceCore(
-            client_id=self.config['client_id'],
-            client_secret=self.config['client_secret'],
-            callback_url=self.config['callback_url'],
-            openai_api_key=self.config['openai_api_key']
+            client_id=self.config["client_id"],
+            client_secret=self.config["client_secret"],
+            callback_url=self.config["callback_url"],
+            openai_api_key=self.config["openai_api_key"],
         )
-        
+        self.token_manager = SecureTokenManager(self.config["fernet_key"])
+
         # Storage for auth flow
         self.current_code_verifier = None
         self.current_character = None
-        
+
     def load_config(self) -> dict:
         """Load configuration from environment or config file"""
-        config_path = 'config.json'
-        
+        config_path = "config.json"
+
         # Try to load from config file first
         if os.path.exists(config_path):
-            with open(config_path, 'r') as f:
+            with open(config_path) as f:
                 return json.load(f)
-        
+
         # Fall back to environment variables
         return {
-            'client_id': os.getenv('EVE_CLIENT_ID', ''),
-            'client_secret': os.getenv('EVE_CLIENT_SECRET', ''),
-            'callback_url': os.getenv('EVE_CALLBACK_URL', 'http://localhost:8765/callback'),
-            'openai_api_key': os.getenv('OPENAI_API_KEY', '')
+            "client_id": os.getenv("EVE_CLIENT_ID", ""),
+            "client_secret": os.getenv("EVE_CLIENT_SECRET", ""),
+            "callback_url": os.getenv("EVE_CALLBACK_URL", "http://localhost:8765/callback"),
+            "openai_api_key": os.getenv("OPENAI_API_KEY", ""),
+            "fernet_key": os.getenv("FERNET_KEY", ""),
         }
-        
+
     def save_config(self, config: dict):
         """Save configuration to file"""
-        with open('config.json', 'w') as f:
+        with open("config.json", "w") as f:
             json.dump(config, f, indent=2)
-            
+
     def setup_wizard(self):
         """Interactive setup for first-time configuration"""
         print("\n=== Sentience Setup Wizard ===\n")
-        
+
         print("You'll need to register an application at https://developers.eveonline.com")
         print("Set the callback URL to: http://localhost:8765/callback\n")
-        
-        self.config['client_id'] = input("Enter your EVE application Client ID: ").strip()
-        self.config['client_secret'] = input("Enter your EVE application Secret Key: ").strip()
-        self.config['openai_api_key'] = input("Enter your OpenAI API key: ").strip()
-        
+
+        self.config["client_id"] = input("Enter your EVE application Client ID: ").strip()
+        self.config["client_secret"] = input("Enter your EVE application Secret Key: ").strip()
+        self.config["openai_api_key"] = input("Enter your OpenAI API key: ").strip()
+        fernet_input = input(
+            "Enter Fernet key for token encryption (leave blank to generate): "
+        ).strip()
+        if not fernet_input:
+            from cryptography.fernet import Fernet
+
+            fernet_input = Fernet.generate_key().decode()
+            print(f"Generated key: {fernet_input}")
+        self.config["fernet_key"] = fernet_input
+
         print("\nSaving configuration...")
         self.save_config(self.config)
-        
+
         # Reinitialize with new config
         self.sentience = SentienceCore(
-            client_id=self.config['client_id'],
-            client_secret=self.config['client_secret'],
-            callback_url=self.config['callback_url'],
-            openai_api_key=self.config['openai_api_key']
+            client_id=self.config["client_id"],
+            client_secret=self.config["client_secret"],
+            callback_url=self.config["callback_url"],
+            openai_api_key=self.config["openai_api_key"],
         )
-        
+
         print("Setup complete! You can now authenticate.\n")
-        
+
     def authenticate(self):
         """Handle OAuth authentication flow"""
         scopes = [
@@ -143,135 +154,137 @@ class SentienceCLI:
             "esi-assets.read_assets.v1",
             "esi-skills.read_skills.v1",
             "esi-industry.read_character_jobs.v1",
-            "esi-markets.read_character_orders.v1"
+            "esi-markets.read_character_orders.v1",
         ]
-        
+
         # Generate auth URL
         auth_url, code_verifier = self.sentience.esi_client.generate_auth_url(scopes)
         self.current_code_verifier = code_verifier
-        
+
         print("\nOpening browser for EVE SSO authentication...")
         print(f"If browser doesn't open, visit: {auth_url}\n")
-        
+
         # Start local server for callback
-        server = HTTPServer(('localhost', 8765), OAuthCallbackHandler)
+        server = HTTPServer(("localhost", 8765), OAuthCallbackHandler)
         server.auth_code = None
-        
+
         # Open browser
         webbrowser.open(auth_url)
-        
+
         # Wait for callback
         print("Waiting for authentication callback...")
         server_thread = threading.Thread(target=server.handle_request)
         server_thread.start()
         server_thread.join(timeout=120)  # 2 minute timeout
-        
+
         if server.auth_code:
             print("Authorization code received!")
-            
+
             try:
                 # Add character
-                character = self.sentience.add_character(server.auth_code, self.current_code_verifier)
+                character = self.sentience.add_character(
+                    server.auth_code, self.current_code_verifier
+                )
                 self.current_character = character
-                
+
                 print(f"\n✓ Successfully authenticated as {character.character_name}")
                 print(f"  Character ID: {character.character_id}")
                 print(f"  Scopes: {', '.join(character.scopes[:3])}...")
-                
+
                 # Save character data for persistence
                 self.save_character(character)
-                
+
             except Exception as e:
                 print(f"\n✗ Authentication failed: {e}")
         else:
             print("\n✗ No authorization code received. Authentication timeout.")
-            
+
         server.server_close()
-        
+
     def save_character(self, character: EVECharacter):
         """Save character data for persistence"""
         char_file = f"character_{character.character_id}.json"
         char_data = {
-            'character_id': character.character_id,
-            'character_name': character.character_name,
-            'refresh_token': character.refresh_token,
-            'scopes': character.scopes,
-            'last_updated': datetime.utcnow().isoformat()
+            "character_id": character.character_id,
+            "character_name": character.character_name,
+            "scopes": character.scopes,
+            "last_updated": datetime.utcnow().isoformat(),
         }
-        
-        with open(char_file, 'w') as f:
+
+        with open(char_file, "w") as f:
             json.dump(char_data, f, indent=2)
-            
+
+        self.token_manager.save_token(str(character.character_id), character.refresh_token)
+
     def load_characters(self) -> list:
         """Load saved characters"""
         characters = []
-        for filename in os.listdir('.'):
-            if filename.startswith('character_') and filename.endswith('.json'):
-                with open(filename, 'r') as f:
+        for filename in os.listdir("."):
+            if filename.startswith("character_") and filename.endswith(".json"):
+                with open(filename) as f:
                     char_data = json.load(f)
                     characters.append(char_data)
         return characters
-        
+
     def interactive_query(self):
         """Interactive query mode"""
         if not self.current_character:
             print("No character authenticated. Please run 'auth' first.")
             return
-            
+
         print(f"\nQuerying as {self.current_character.character_name}")
         print("Type 'exit' to return to main menu\n")
-        
+
         while True:
             query = input("Sentience> ").strip()
-            
-            if query.lower() in ['exit', 'quit', 'back']:
+
+            if query.lower() in ["exit", "quit", "back"]:
                 break
-                
+
             if not query:
                 continue
-                
+
             print("\nProcessing query...")
-            
+
             try:
                 response = self.sentience.query_assistant(
-                    str(self.current_character.character_id),
-                    query
+                    str(self.current_character.character_id), query
                 )
                 print(f"\n{response}\n")
             except Exception as e:
                 print(f"\nError: {e}\n")
-                
+
     def show_data_preview(self):
         """Show raw data preview for debugging"""
         if not self.current_character:
             print("No character authenticated.")
             return
-            
+
         print(f"\nFetching data for {self.current_character.character_name}...\n")
-        
+
         try:
             # Fetch wallet
             wallet = self.sentience.esi_client.get_character_wallet(self.current_character)
             print(f"Wallet Balance: {wallet.balance:,.2f} ISK")
-            
+
             # Fetch assets summary
             assets = self.sentience.esi_client.get_character_assets(self.current_character)
             print(f"Total Assets: {len(assets)} items")
-            
+
             # Show first few assets
             print("\nFirst 5 assets:")
             for asset in assets[:5]:
                 print(f"  - Item {asset.item_id}: {asset.quantity}x Type {asset.type_id}")
-                
+
             # Fetch skills summary
             skills = self.sentience.esi_client.get_character_skills(self.current_character)
             total_sp = sum(s.skillpoints for s in skills)
             print(f"\nTotal Skillpoints: {total_sp:,}")
             print(f"Skills Trained: {len(skills)}")
-            
+
         except Exception as e:
             print(f"Error fetching data: {e}")
-            
+
     def main_menu(self):
         """Display main menu"""
         while True:
@@ -282,18 +295,18 @@ class SentienceCLI:
             print("4. Show data preview")
             print("5. List saved characters")
             print("6. Exit")
-            
+
             choice = input("\nSelect option: ").strip()
-            
-            if choice == '1':
+
+            if choice == "1":
                 self.setup_wizard()
-            elif choice == '2':
+            elif choice == "2":
                 self.authenticate()
-            elif choice == '3':
+            elif choice == "3":
                 self.interactive_query()
-            elif choice == '4':
+            elif choice == "4":
                 self.show_data_preview()
-            elif choice == '5':
+            elif choice == "5":
                 chars = self.load_characters()
                 if chars:
                     print("\nSaved characters:")
@@ -301,7 +314,7 @@ class SentienceCLI:
                         print(f"  - {char['character_name']} (ID: {char['character_id']})")
                 else:
                     print("\nNo saved characters found.")
-            elif choice == '6':
+            elif choice == "6":
                 print("\nFly safe o7")
                 break
             else:

--- a/src/sentience/utils/__init__.py
+++ b/src/sentience/utils/__init__.py
@@ -3,5 +3,6 @@ Sentience utilities package
 """
 
 from sentience.utils.config import Config, get_config
+from sentience.utils.token_manager import SecureTokenManager
 
-__all__ = ["Config", "get_config"]
+__all__ = ["Config", "get_config", "SecureTokenManager"]

--- a/src/sentience/utils/config.py
+++ b/src/sentience/utils/config.py
@@ -15,84 +15,85 @@ logger = logging.getLogger(__name__)
 
 class Config:
     """Centralized configuration management"""
-    
+
     def __init__(self, config_path: Optional[Path] = None):
         self.config_path = config_path or Path("config.json")
         self.config: Dict[str, Any] = {}
         self._load_config()
-        
+
     def _load_config(self) -> None:
         """Load configuration from environment and/or config file"""
         # Load .env file if it exists
         dotenv.load_dotenv()
-        
+
         # Try to load from config file first
         if self.config_path.exists():
             try:
-                with open(self.config_path, 'r') as f:
+                with open(self.config_path) as f:
                     self.config = json.load(f)
                 logger.info(f"Loaded configuration from {self.config_path}")
             except Exception as e:
                 logger.warning(f"Failed to load config file: {e}")
-        
+
         # Override with environment variables
         env_mapping = {
-            'client_id': 'EVE_CLIENT_ID',
-            'client_secret': 'EVE_CLIENT_SECRET',
-            'callback_url': 'EVE_CALLBACK_URL',
-            'openai_api_key': 'OPENAI_API_KEY',
+            "client_id": "EVE_CLIENT_ID",
+            "client_secret": "EVE_CLIENT_SECRET",
+            "callback_url": "EVE_CALLBACK_URL",
+            "openai_api_key": "OPENAI_API_KEY",
+            "fernet_key": "FERNET_KEY",
         }
-        
+
         for key, env_var in env_mapping.items():
             env_value = os.getenv(env_var)
             if env_value:
                 self.config[key] = env_value
-                
+
         # Set defaults
         defaults = {
-            'callback_url': 'http://localhost:8000/callback',
-            'cache_ttl': 300,
-            'log_level': 'INFO',
+            "callback_url": "http://localhost:8000/callback",
+            "cache_ttl": 300,
+            "log_level": "INFO",
         }
-        
+
         for key, default_value in defaults.items():
             if key not in self.config:
                 self.config[key] = default_value
-                
+
     def get(self, key: str, default: Any = None) -> Any:
         """Get configuration value"""
         return self.config.get(key, default)
-        
+
     def set(self, key: str, value: Any) -> None:
         """Set configuration value"""
         self.config[key] = value
-        
+
     def save(self) -> None:
         """Save configuration to file"""
         try:
-            with open(self.config_path, 'w') as f:
+            with open(self.config_path, "w") as f:
                 json.dump(self.config, f, indent=2)
             logger.info(f"Saved configuration to {self.config_path}")
         except Exception as e:
             logger.error(f"Failed to save config: {e}")
-            
+
     def validate(self) -> bool:
         """Validate required configuration values"""
-        required_keys = ['client_id', 'client_secret', 'openai_api_key']
+        required_keys = ["client_id", "client_secret", "openai_api_key", "fernet_key"]
         missing_keys = [key for key in required_keys if not self.get(key)]
-        
+
         if missing_keys:
             logger.error(f"Missing required configuration: {', '.join(missing_keys)}")
             return False
-            
+
         return True
-        
+
     def setup_logging(self) -> None:
         """Configure logging based on config"""
-        log_level = self.get('log_level', 'INFO')
+        log_level = self.get("log_level", "INFO")
         logging.basicConfig(
             level=getattr(logging, log_level),
-            format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+            format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
         )
 
 

--- a/src/sentience/utils/token_manager.py
+++ b/src/sentience/utils/token_manager.py
@@ -1,0 +1,36 @@
+import logging
+from pathlib import Path
+from typing import Optional
+
+from cryptography.fernet import Fernet
+
+logger = logging.getLogger(__name__)
+
+
+class SecureTokenManager:
+    """Encrypt and store refresh tokens using Fernet."""
+
+    def __init__(self, key: str, token_dir: Path = Path("tokens")) -> None:
+        self.fernet = Fernet(key)
+        self.token_dir = token_dir
+        self.token_dir.mkdir(exist_ok=True)
+
+    def save_token(self, identifier: str, token: str) -> None:
+        """Encrypt and save a refresh token."""
+        token_path = self.token_dir / f"{identifier}.token"
+        encrypted = self.fernet.encrypt(token.encode())
+        with open(token_path, "wb") as f:
+            f.write(encrypted)
+
+    def load_token(self, identifier: str) -> Optional[str]:
+        """Load and decrypt a refresh token."""
+        token_path = self.token_dir / f"{identifier}.token"
+        if not token_path.exists():
+            return None
+
+        try:
+            encrypted = token_path.read_bytes()
+            return self.fernet.decrypt(encrypted).decode()
+        except Exception as exc:  # broad catch to avoid failing on corrupt token
+            logger.error("Failed to decrypt token %s: %s", identifier, exc)
+            return None

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,19 +2,20 @@
 Tests for configuration management
 """
 
-import logging
 import json
+import logging
 import os
-import pytest
 from pathlib import Path
-from unittest.mock import patch, mock_open, MagicMock
+from unittest.mock import mock_open, patch
+
+import pytest
 
 from sentience.utils.config import Config, get_config
 
 
 class TestConfig:
     """Test cases for Config class"""
-    
+
     @pytest.fixture
     def temp_config_file(self, tmp_path):
         """Create a temporary config file"""
@@ -23,179 +24,188 @@ class TestConfig:
             "client_id": "test_client_id",
             "client_secret": "test_client_secret",
             "callback_url": "http://localhost:8000/callback",
-            "openai_api_key": "test_openai_key"
+            "openai_api_key": "test_openai_key",
+            "fernet_key": "test_fernet_key",
         }
         config_path.write_text(json.dumps(config_data))
         return config_path
-    
+
     @pytest.fixture
     def env_vars(self):
         """Set up test environment variables"""
         env_vars = {
-            'EVE_CLIENT_ID': 'env_client_id',
-            'EVE_CLIENT_SECRET': 'env_client_secret',
-            'EVE_CALLBACK_URL': 'http://localhost:9000/callback',
-            'OPENAI_API_KEY': 'env_openai_key'
+            "EVE_CLIENT_ID": "env_client_id",
+            "EVE_CLIENT_SECRET": "env_client_secret",
+            "EVE_CALLBACK_URL": "http://localhost:9000/callback",
+            "OPENAI_API_KEY": "env_openai_key",
+            "FERNET_KEY": "env_fernet_key",
         }
         with patch.dict(os.environ, env_vars, clear=False):
             yield env_vars
-    
+
     def test_config_initialization_default_path(self):
         """Test Config initialization with default path"""
         config = Config()
         assert config.config_path == Path("config.json")
         assert isinstance(config.config, dict)
-    
+
     def test_config_initialization_custom_path(self, tmp_path):
         """Test Config initialization with custom path"""
         custom_path = tmp_path / "custom_config.json"
         config = Config(config_path=custom_path)
         assert config.config_path == custom_path
-    
+
     def test_load_config_from_file(self, temp_config_file):
         """Test loading configuration from file"""
         config = Config(config_path=temp_config_file)
-        
-        assert config.get('client_id') == 'test_client_id'
-        assert config.get('client_secret') == 'test_client_secret'
-        assert config.get('callback_url') == 'http://localhost:8000/callback'
-        assert config.get('openai_api_key') == 'test_openai_key'
-    
+
+        assert config.get("client_id") == "test_client_id"
+        assert config.get("client_secret") == "test_client_secret"
+        assert config.get("callback_url") == "http://localhost:8000/callback"
+        assert config.get("openai_api_key") == "test_openai_key"
+        assert config.get("fernet_key") == "test_fernet_key"
+
     def test_load_config_from_env(self, env_vars):
         """Test loading configuration from environment variables"""
         # Create config with non-existent file to force env loading
         config = Config(config_path=Path("non_existent.json"))
-        
-        assert config.get('client_id') == 'env_client_id'
-        assert config.get('client_secret') == 'env_client_secret'
-        assert config.get('callback_url') == 'http://localhost:9000/callback'
-        assert config.get('openai_api_key') == 'env_openai_key'
-    
+
+        assert config.get("client_id") == "env_client_id"
+        assert config.get("client_secret") == "env_client_secret"
+        assert config.get("callback_url") == "http://localhost:9000/callback"
+        assert config.get("openai_api_key") == "env_openai_key"
+        assert config.get("fernet_key") == "env_fernet_key"
+
     def test_env_overrides_file(self, temp_config_file, env_vars):
         """Test environment variables override file values"""
         config = Config(config_path=temp_config_file)
-        
+
         # Environment values should override file values
-        assert config.get('client_id') == 'env_client_id'
-        assert config.get('client_secret') == 'env_client_secret'
-        assert config.get('callback_url') == 'http://localhost:9000/callback'
-        assert config.get('openai_api_key') == 'env_openai_key'
-    
+        assert config.get("client_id") == "env_client_id"
+        assert config.get("client_secret") == "env_client_secret"
+        assert config.get("callback_url") == "http://localhost:9000/callback"
+        assert config.get("openai_api_key") == "env_openai_key"
+        assert config.get("fernet_key") == "env_fernet_key"
+
     def test_default_values(self):
         """Test default configuration values"""
         config = Config(config_path=Path("non_existent.json"))
-        
-        assert config.get('cache_ttl') == 300
-        assert config.get('log_level') == 'INFO'
-        assert config.get('callback_url') == 'http://localhost:8000/callback'
-    
+
+        assert config.get("cache_ttl") == 300
+        assert config.get("log_level") == "INFO"
+        assert config.get("callback_url") == "http://localhost:8000/callback"
+
     def test_get_with_default(self):
         """Test getting configuration value with default"""
         config = Config(config_path=Path("non_existent.json"))
-        
-        assert config.get('non_existent_key') is None
-        assert config.get('non_existent_key', 'default_value') == 'default_value'
-    
+
+        assert config.get("non_existent_key") is None
+        assert config.get("non_existent_key", "default_value") == "default_value"
+
     def test_set_value(self):
         """Test setting configuration value"""
         config = Config(config_path=Path("non_existent.json"))
-        
-        config.set('test_key', 'test_value')
-        assert config.get('test_key') == 'test_value'
-        
-        config.set('test_number', 42)
-        assert config.get('test_number') == 42
-    
+
+        config.set("test_key", "test_value")
+        assert config.get("test_key") == "test_value"
+
+        config.set("test_number", 42)
+        assert config.get("test_number") == 42
+
     def test_save_config(self, tmp_path):
         """Test saving configuration to file"""
         config_path = tmp_path / "save_test.json"
         config = Config(config_path=config_path)
-        
+
         # Set some values
-        config.set('client_id', 'saved_client_id')
-        config.set('client_secret', 'saved_secret')
-        
+        config.set("client_id", "saved_client_id")
+        config.set("client_secret", "saved_secret")
+
         # Save config
         config.save()
-        
+
         # Verify file was created and contains correct data
         assert config_path.exists()
         saved_data = json.loads(config_path.read_text())
-        assert saved_data['client_id'] == 'saved_client_id'
-        assert saved_data['client_secret'] == 'saved_secret'
-    
+        assert saved_data["client_id"] == "saved_client_id"
+        assert saved_data["client_secret"] == "saved_secret"
+
     def test_save_config_error_handling(self):
         """Test error handling when saving config fails"""
         config = Config(config_path=Path("/invalid/path/config.json"))
-        
+
         # Should not raise exception
         config.save()
-    
+
     def test_validate_valid_config(self):
         """Test validation with all required values present"""
         config = Config(config_path=Path("non_existent.json"))
-        config.set('client_id', 'test_id')
-        config.set('client_secret', 'test_secret')
-        config.set('openai_api_key', 'test_key')
-        
+        config.set("client_id", "test_id")
+        config.set("client_secret", "test_secret")
+        config.set("openai_api_key", "test_key")
+        config.set("fernet_key", "test_key2")
+
         assert config.validate() is True
-    
+
     def test_validate_missing_required(self):
         """Test validation with missing required values"""
         config = Config(config_path=Path("non_existent.json"))
-        config.set('client_id', 'test_id')
+        config.set("client_id", "test_id")
         # Missing client_secret and openai_api_key
-        
+        config.set("fernet_key", "test")
+
         assert config.validate() is False
-    
+
     def test_validate_empty_values(self):
         """Test validation with empty string values"""
         config = Config(config_path=Path("non_existent.json"))
-        config.set('client_id', '')
-        config.set('client_secret', 'test_secret')
-        config.set('openai_api_key', 'test_key')
-        
+        config.set("client_id", "")
+        config.set("client_secret", "test_secret")
+        config.set("openai_api_key", "test_key")
+        config.set("fernet_key", "")
+
         assert config.validate() is False
-    
-    @patch('logging.basicConfig')
+
+    @patch("logging.basicConfig")
     def test_setup_logging(self, mock_logging_config):
         """Test logging setup"""
         config = Config(config_path=Path("non_existent.json"))
-        config.set('log_level', 'DEBUG')
-        
+        config.set("log_level", "DEBUG")
+
         config.setup_logging()
-        
+
         mock_logging_config.assert_called_once()
         call_args = mock_logging_config.call_args[1]
-        assert call_args['level'] == logging.DEBUG
-        assert '%(asctime)s' in call_args['format']
-        assert '%(levelname)s' in call_args['format']
-    
+        assert call_args["level"] == logging.DEBUG
+        assert "%(asctime)s" in call_args["format"]
+        assert "%(levelname)s" in call_args["format"]
+
     def test_dotenv_loading(self):
         """Test .env file loading"""
         env_content = """
 EVE_CLIENT_ID=dotenv_client_id
 EVE_CLIENT_SECRET=dotenv_secret
 OPENAI_API_KEY=dotenv_openai_key
+FERNET_KEY=dotenv_key
 """
-        
-        with patch('pathlib.Path.exists', return_value=True):
-            with patch('builtins.open', mock_open(read_data=env_content)):
-                with patch('dotenv.load_dotenv') as mock_load_dotenv:
+
+        with patch("pathlib.Path.exists", return_value=True):
+            with patch("builtins.open", mock_open(read_data=env_content)):
+                with patch("dotenv.load_dotenv") as mock_load_dotenv:
                     config = Config(config_path=Path("non_existent.json"))
                     mock_load_dotenv.assert_called_once()
 
 
 class TestGetConfig:
     """Test cases for get_config function"""
-    
+
     def test_get_config_singleton(self):
         """Test get_config returns singleton instance"""
         config1 = get_config()
         config2 = get_config()
-        
+
         assert config1 is config2
-    
+
     def test_get_config_instance_type(self):
         """Test get_config returns Config instance"""
         config = get_config()

--- a/tests/test_token_manager.py
+++ b/tests/test_token_manager.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+
+from cryptography.fernet import Fernet
+
+from sentience.utils.token_manager import SecureTokenManager
+
+
+def test_token_round_trip(tmp_path: Path) -> None:
+    key = Fernet.generate_key().decode()
+    manager = SecureTokenManager(key, token_dir=tmp_path)
+    manager.save_token("123", "secret")
+    assert (tmp_path / "123.token").exists()
+    assert manager.load_token("123") == "secret"
+
+
+def test_token_wrong_key(tmp_path: Path) -> None:
+    key = Fernet.generate_key().decode()
+    manager = SecureTokenManager(key, token_dir=tmp_path)
+    manager.save_token("abc", "value")
+
+    other = SecureTokenManager(Fernet.generate_key().decode(), token_dir=tmp_path)
+    assert other.load_token("abc") is None


### PR DESCRIPTION
## Summary
- encrypt refresh tokens using new `SecureTokenManager`
- require `FERNET_KEY` in configuration and setup
- store tokens encrypted in both API server and CLI
- document key generation instructions
- add tests for token manager

## Testing
- `ruff check src/sentience/utils/token_manager.py src/sentience/utils/__init__.py src/sentience/utils/config.py src/sentience/api/server.py src/sentience/cli/__main__.py tests/test_token_manager.py tests/test_config.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687447b73e288331a2b859c5e1f34efa